### PR TITLE
chore(continuous.yml): change ci to public

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.13'
-      - name: Install gcc
-        run: sudo apt update && sudo apt install -y gcc
       - name: Check code format
         run: |
           UNFORMATED=$(gofmt -l ./incognia/)


### PR DESCRIPTION
As this will be a public repo, we need to change the CI to use a public runner