### PR TITLE
feat(request_types): add chargeback_notification feedback event type

### DIFF
--- a/request_types.go
+++ b/request_types.go
@@ -50,6 +50,7 @@ const (
 	PromotionAbuse                FeedbackType = "promotion_abuse"
 	AccountTakeover               FeedbackType = "account_takeover"
 	MposFraud                     FeedbackType = "mpos_fraud"
+	ChargebackNotification        FeedbackType = "chargeback_notification"
 )
 
 type postFeedbackRequestBody struct {


### PR DESCRIPTION
This adds a new `chargeback_notification` event type for feedback API