### PR TITLE
feat(incognia): add Authenticate method

### DIFF
--- a/credentials_manager.go
+++ b/credentials_manager.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -61,6 +62,10 @@ func (tm *clientCredentialsTokenManager) refreshToken() error {
 
 	if res.StatusCode == http.StatusUnauthorized {
 		return ErrInvalidCredentials
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return errors.New("Error refreshing token: " + strconv.Itoa(res.StatusCode))
 	}
 
 	defer res.Body.Close()

--- a/incognia.go
+++ b/incognia.go
@@ -98,6 +98,18 @@ func New(config *IncogniaClientConfig) (*Client, error) {
 	return client, nil
 }
 
+func (c *Client) Authenticate() error {
+	return c.tokenManager.refreshToken()
+}
+
+func (c *Client) GetAuthenticationExpiresInSeconds() int64 {
+	token := c.tokenManager.Token
+	if token != nil {
+		return token.ExpiresIn
+	}
+	return 0
+}
+
 func (c *Client) GetSignupAssessment(signupID string) (*SignupAssessment, error) {
 	if signupID == "" {
 		return nil, ErrMissingSignupID


### PR DESCRIPTION
It exposes the "Authenticate" method, so it enables clients to refresh the token in a second thread if they want.

Usage example:

```
go func(i *incognia.Client) {
   for {
       i.Authenticate()
       time.Sleep(time.Second * i.GetAuthenticationExpiresInSeconds())
   }
}
```