### PR TITLE
fix(token_provider): avoid concurrent token refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 test:
 	mkdir -p coverage
 	go test -coverprofile coverage/coverage.out $(shell go list ./... | grep -v /vendor/) -p 1
+	go test -race -coverprofile coverage/coverage_race.out $(shell go list ./... | grep -v /vendor/) -run "TestAutoRefreshTokenProviderTestSuite|TestManualRefreshTokenProviderTestSuite" -p 1

--- a/token_provider.go
+++ b/token_provider.go
@@ -75,17 +75,15 @@ func NewAutoRefreshTokenProvider(tokenClient *TokenClient) *AutoRefreshTokenProv
 }
 
 func (t *AutoRefreshTokenProvider) GetToken() (Token, error) {
-	var unlockOnce sync.Once
-
 	t.tokenMutex.RLock()
-	defer unlockOnce.Do(t.tokenMutex.RUnlock)
+	token := t.token
+	t.tokenMutex.RUnlock()
 
-	if t.token == nil || t.token.IsExpired() {
-		unlockOnce.Do(t.tokenMutex.RUnlock)
-		return t.refresh()
+	if token != nil && !token.IsExpired() {
+		return token, nil
 	}
 
-	return t.token, nil
+	return t.refresh()
 }
 
 func (t *AutoRefreshTokenProvider) refresh() (Token, error) {


### PR DESCRIPTION
Solves https://github.com/inloco/incognia-go/issues/31

For the case of AutoRefreshTokenProvider, we guarantee only one call to our servers, but we can't guarantee that with the ManualRefreshTokenProvider, as it depends on client implementation
