### PR TITLE
feat(incognia.go): adds new header with the user-agent information

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/stretchr/testify v1.6.1
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
+
+replace github.com/matishsiao/goInfo => github.com/wakatime/goInfo v0.1.0-wakatime.8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f h1:B0OD7nYl2FPQEVrw8g2uyc1lGEzNbvrKh7fspGZcbvY=
+github.com/matishsiao/goInfo v0.0.0-20210923090445-da2e3fa8d45f/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/wakatime/goInfo v0.1.0-wakatime.8 h1:MgyeRnCkynEmUxLKXnYUAP5Dd+vhKxhqg6Nx1PdAZy4=
+github.com/wakatime/goInfo v0.1.0-wakatime.8/go.mod h1:aEt7p9Rvh67BYApmZwNDPpgircTO2kgdmDUoF/1QmwA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -764,6 +764,8 @@ func (suite *IncogniaTestSuite) mockFeedbackEndpoint(expectedToken string, expec
 			return
 		}
 
+		suite.Contains(r.Header, userAgentKey)
+
 		var requestBody postFeedbackRequestBody
 		json.NewDecoder(r.Body).Decode(&requestBody)
 
@@ -807,6 +809,8 @@ func (suite *IncogniaTestSuite) mockPostTransactionsEndpoint(expectedToken strin
 			return
 		}
 
+		suite.Contains(r.Header, userAgentKey)
+
 		requestQueryString := r.URL.Query()
 		for parameter := range requestQueryString {
 			suite.Equal(expectedQueryString[parameter], requestQueryString[parameter])
@@ -845,6 +849,8 @@ func (suite *IncogniaTestSuite) mockPostSignupsEndpoint(expectedToken string, ex
 			return
 		}
 
+		suite.Contains(r.Header, userAgentKey)
+
 		var requestBody postAssessmentRequestBody
 		json.NewDecoder(r.Body).Decode(&requestBody)
 
@@ -870,6 +876,8 @@ func (suite *IncogniaTestSuite) mockGetSignupsEndpoint(expectedToken, expectedSi
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+
+		suite.Contains(r.Header, userAgentKey)
 
 		defer r.Body.Close()
 


### PR DESCRIPTION
This PR adds a new header containing a 'User-Agent' header, it should contain the following format:

\<library-name\>/\<library-version\> (\<os-name\> \<os-version\> \<os-arch\>) \<language-name\>/\<language-version\>
i got the following outcome running locally 
"incognia-go/1.8.0 (GNU/Linux 5.13.0-39-generic x86_64) golang/go1.17"
