### PR TITLE
Add policy-id to postTransactionRequestBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ assessment, err := client.RegisterPayment(&incognia.Payment{
     InstallationID: "installation-id",
     AccountID:      "account-id",
     ExternalID:     "external-id",
+    PolicyID:       "policy-id",
     Addresses: []*incognia.TransactionAddress{
         {
             Type: incognia.Billing,
@@ -156,6 +157,7 @@ assessment, err := client.RegisterLogin(&incognia.Login{
     InstallationID: "installation-id",
     AccountID:      "account-id",
     ExternalID:     "external-id",
+    PolicyID:       "policy-id",
 })
 ```
 
@@ -174,6 +176,7 @@ assessment, err := client.RegisterLogin(&incognia.Login{
     InstallationID: "installation-id",
     AccountID:      "account-id",
     ExternalID:     "external-id",
+    PolicyID:       "policy-id",
 })
 ```
 
@@ -186,6 +189,7 @@ assessment, err := client.RegisterPayment(&incognia.Payment{
     InstallationID: "installation-id",
     AccountID:      "account-id",
     ExternalID:     "external-id",
+    PolicyID:       "policy-id",
     Addresses: []*incognia.TransactionAddress{
         {
             Type: incognia.Billing,

--- a/incognia.go
+++ b/incognia.go
@@ -55,6 +55,7 @@ type Payment struct {
 	InstallationID string
 	AccountID      string
 	ExternalID     string
+	PolicyID       string
 	Addresses      []*TransactionAddress
 	Value          *PaymentValue
 	Methods        []*PaymentMethod
@@ -65,6 +66,7 @@ type Login struct {
 	InstallationID string
 	AccountID      string
 	ExternalID     string
+	PolicyID       string
 	Eval           *bool
 }
 
@@ -273,6 +275,7 @@ func (c *Client) registerPayment(payment *Payment) (ret *TransactionAssessment, 
 		InstallationID: payment.InstallationID,
 		Type:           paymentType,
 		AccountID:      payment.AccountID,
+		PolicyID:       payment.PolicyID,
 		ExternalID:     payment.ExternalID,
 		Addresses:      payment.Addresses,
 		PaymentValue:   payment.Value,
@@ -331,6 +334,7 @@ func (c *Client) registerLogin(login *Login) (*TransactionAssessment, error) {
 		InstallationID: login.InstallationID,
 		Type:           loginType,
 		AccountID:      login.AccountID,
+		PolicyID:       login.PolicyID,
 		ExternalID:     login.ExternalID,
 	})
 	if err != nil {

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -131,6 +131,7 @@ var (
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Type:           paymentType,
 		Addresses: []*TransactionAddress{
 			{
@@ -180,6 +181,7 @@ var (
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Addresses: []*TransactionAddress{
 			{
 				Type: Billing,
@@ -227,41 +229,48 @@ var (
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Eval:           &shouldEval,
 	}
 	simplePaymentFixtureWithShouldNotEval = &Payment{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Eval:           &shouldNotEval,
 	}
 	postSimplePaymentRequestBodyFixture = &postTransactionRequestBody{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Type:           paymentType,
 	}
 	loginFixture = &Login{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 	}
 	loginFixtureWithShouldEval = &Login{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Eval:           &shouldEval,
 	}
 	loginFixtureWithShouldNotEval = &Login{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Eval:           &shouldNotEval,
 	}
 	postLoginRequestBodyFixture = &postTransactionRequestBody{
 		InstallationID: "installation-id",
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
+		PolicyID:       "policy-id",
 		Type:           loginType,
 	}
 )

--- a/request_types.go
+++ b/request_types.go
@@ -118,6 +118,7 @@ type PaymentMethod struct {
 
 type postTransactionRequestBody struct {
 	ExternalID     string                `json:"external_id,omitempty"`
+	PolicyID       string                `json:"policy_id,omitempty"`
 	InstallationID string                `json:"installation_id"`
 	Type           transactionType       `json:"type"`
 	AccountID      string                `json:"account_id"`


### PR DESCRIPTION
Add support to policy-id attribute on Payment and Login request body:

![image](https://github.com/inloco/incognia-go/assets/1418294/14b315d0-2c6d-4ee6-b5aa-028b0428f796)

P.S.: [Incognia Docs (login needed)](https://developer.incognia.com/docs/us/v6/apis/login-api)