### PR TITLE
Add `payment-method-identifier` to postTransactionRequestBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ This method registers a new login for the given installation and account, return
 
 ```go
 assessment, err := client.RegisterLogin(&incognia.Login{
-    InstallationID: "installation-id",
-    AccountID:      "account-id",
-    ExternalID:     "external-id",
-    PolicyID:       "policy-id",
+InstallationID:                 "installation-id",
+    AccountID:                  "account-id",
+    ExternalID:                 "external-id",
+    PolicyID:                   "policy-id",
+    PaymentMethodIdentifier:    "payment-method-identifier",
 })
 ```
 

--- a/incognia.go
+++ b/incognia.go
@@ -63,11 +63,12 @@ type Payment struct {
 }
 
 type Login struct {
-	InstallationID string
-	AccountID      string
-	ExternalID     string
-	PolicyID       string
-	Eval           *bool
+	InstallationID          string
+	AccountID               string
+	ExternalID              string
+	PolicyID                string
+	PaymentMethodIdentifier string
+	Eval                    *bool
 }
 
 type FeedbackIdentifiers struct {
@@ -331,11 +332,12 @@ func (c *Client) registerLogin(login *Login) (*TransactionAssessment, error) {
 	}
 
 	requestBody, err := json.Marshal(postTransactionRequestBody{
-		InstallationID: login.InstallationID,
-		Type:           loginType,
-		AccountID:      login.AccountID,
-		PolicyID:       login.PolicyID,
-		ExternalID:     login.ExternalID,
+		InstallationID:          login.InstallationID,
+		Type:                    loginType,
+		AccountID:               login.AccountID,
+		PolicyID:                login.PolicyID,
+		ExternalID:              login.ExternalID,
+		PaymentMethodIdentifier: login.PaymentMethodIdentifier,
 	})
 	if err != nil {
 		return nil, err

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -247,17 +247,19 @@ var (
 		Type:           paymentType,
 	}
 	loginFixture = &Login{
-		InstallationID: "installation-id",
-		AccountID:      "account-id",
-		ExternalID:     "external-id",
-		PolicyID:       "policy-id",
+		InstallationID:          "installation-id",
+		AccountID:               "account-id",
+		ExternalID:              "external-id",
+		PolicyID:                "policy-id",
+		PaymentMethodIdentifier: "payment-method-identifier",
 	}
 	loginFixtureWithShouldEval = &Login{
-		InstallationID: "installation-id",
-		AccountID:      "account-id",
-		ExternalID:     "external-id",
-		PolicyID:       "policy-id",
-		Eval:           &shouldEval,
+		InstallationID:          "installation-id",
+		AccountID:               "account-id",
+		ExternalID:              "external-id",
+		PolicyID:                "policy-id",
+		PaymentMethodIdentifier: "payment-method-identifier",
+		Eval:                    &shouldEval,
 	}
 	loginFixtureWithShouldNotEval = &Login{
 		InstallationID: "installation-id",
@@ -267,11 +269,12 @@ var (
 		Eval:           &shouldNotEval,
 	}
 	postLoginRequestBodyFixture = &postTransactionRequestBody{
-		InstallationID: "installation-id",
-		AccountID:      "account-id",
-		ExternalID:     "external-id",
-		PolicyID:       "policy-id",
-		Type:           loginType,
+		InstallationID:          "installation-id",
+		AccountID:               "account-id",
+		ExternalID:              "external-id",
+		PolicyID:                "policy-id",
+		PaymentMethodIdentifier: "payment-method-identifier",
+		Type:                    loginType,
 	}
 )
 

--- a/request_types.go
+++ b/request_types.go
@@ -117,12 +117,13 @@ type PaymentMethod struct {
 }
 
 type postTransactionRequestBody struct {
-	ExternalID     string                `json:"external_id,omitempty"`
-	PolicyID       string                `json:"policy_id,omitempty"`
-	InstallationID string                `json:"installation_id"`
-	Type           transactionType       `json:"type"`
-	AccountID      string                `json:"account_id"`
-	Addresses      []*TransactionAddress `json:"addresses,omitempty"`
-	PaymentValue   *PaymentValue         `json:"payment_value,omitempty"`
-	PaymentMethods []*PaymentMethod      `json:"payment_methods,omitempty"`
+	ExternalID              string                `json:"external_id,omitempty"`
+	PolicyID                string                `json:"policy_id,omitempty"`
+	InstallationID          string                `json:"installation_id"`
+	PaymentMethodIdentifier string                `json:"payment_method_identifier,omitempty"`
+	Type                    transactionType       `json:"type"`
+	AccountID               string                `json:"account_id"`
+	Addresses               []*TransactionAddress `json:"addresses,omitempty"`
+	PaymentValue            *PaymentValue         `json:"payment_value,omitempty"`
+	PaymentMethods          []*PaymentMethod      `json:"payment_methods,omitempty"`
 }


### PR DESCRIPTION
This PR adds the `payment-method-identifier` field to `postTransactionRequestBody`. 

