### PR TITLE
refactor: use RFC3339 fields in requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,15 +284,11 @@ assessment, err := client.RegisterPayment(&incognia.Payment{
 This method registers a feedback event for the given identifiers (represented in `FeedbackIdentifiers`) related to a signup, login or payment.
 
 ```go
-timestamp := time.Now()
-feedbackEvent := incognia.SignupAccepted
-err := client.RegisterFeedback(feedbackEvent, &timestamp, &incognia.FeedbackIdentifiers{
-		InstallationID: "some-installation-id",
-		LoginID:        "some-login-id",
-		PaymentID:      "some-payment-id",
-		SignupID:       "some-signup-id",
-		AccountID:      "some-account-id",
-		ExternalID:     "some-external-id",
+occurred_at := time.Parse(time.RFC3339, "2024-07-22T15:20:00Z")
+feedbackEvent := incognia.AccountTakeover
+err := client.RegisterFeedback(feedbackEvent, &occurred_at, &incognia.FeedbackIdentifiers{
+    InstallationID: "some-installation-id",
+    AccountID:      "some-account-id",
 })
 ```
 

--- a/incognia.go
+++ b/incognia.go
@@ -234,27 +234,27 @@ func (c *Client) registerSignup(params *Signup) (ret *SignupAssessment, err erro
 	return &signupAssessment, nil
 }
 
-func (c *Client) RegisterFeedback(feedbackEvent FeedbackType, timestamp *time.Time, feedbackIdentifiers *FeedbackIdentifiers) (err error) {
+func (c *Client) RegisterFeedback(feedbackEvent FeedbackType, occurredAt *time.Time, feedbackIdentifiers *FeedbackIdentifiers) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("%v", r)
 		}
 	}()
 
-	return c.registerFeedback(feedbackEvent, timestamp, feedbackIdentifiers)
+	return c.registerFeedback(feedbackEvent, occurredAt, feedbackIdentifiers)
 }
 
-func (c *Client) registerFeedback(feedbackEvent FeedbackType, timestamp *time.Time, feedbackIdentifiers *FeedbackIdentifiers) (err error) {
+func (c *Client) registerFeedback(feedbackEvent FeedbackType, occurredAt *time.Time, feedbackIdentifiers *FeedbackIdentifiers) (err error) {
 	if !isValidFeedbackType(feedbackEvent) {
 		return ErrInvalidFeedbackType
 	}
-	if timestamp == nil {
+	if occurredAt == nil {
 		return ErrMissingTimestamp
 	}
 
 	requestBody := postFeedbackRequestBody{
-		Event:     feedbackEvent,
-		Timestamp: timestamp.UnixNano() / 1000000,
+		Event:      feedbackEvent,
+		OccurredAt: occurredAt,
 	}
 	if feedbackIdentifiers != nil {
 		requestBody.InstallationID = feedbackIdentifiers.InstallationID

--- a/request_types.go
+++ b/request_types.go
@@ -1,5 +1,7 @@
 package incognia
 
+import "time"
+
 type Coordinates struct {
 	Lat float64 `json:"lat"`
 	Lng float64 `json:"lng"`
@@ -57,7 +59,7 @@ const (
 
 type postFeedbackRequestBody struct {
 	Event          FeedbackType `json:"event"`
-	Timestamp      int64        `json:"timestamp"`
+	OccurredAt     *time.Time   `json:"occurred_at,omitempty"`
 	InstallationID string       `json:"installation_id,omitempty"`
 	LoginID        string       `json:"login_id,omitempty"`
 	PaymentID      string       `json:"payment_id,omitempty"`


### PR DESCRIPTION
Fields that received timestamp as Epoch milliseconds have been replaced with other fields that receives date-time as RFC3339 strings.

This PRs makes use of the new fields.