### PR TITLE
fix: remove restriction on feedback type

### DIFF
--- a/incognia.go
+++ b/incognia.go
@@ -257,10 +257,6 @@ func (c *Client) RegisterFeedbackWithExpiration(feedbackEvent FeedbackType, occu
 }
 
 func (c *Client) registerFeedback(feedbackEvent FeedbackType, occurredAt *time.Time, expiresAt *time.Time, feedbackIdentifiers *FeedbackIdentifiers) (err error) {
-	if !isValidFeedbackType(feedbackEvent) {
-		return ErrInvalidFeedbackType
-	}
-
 	requestBody := postFeedbackRequestBody{
 		Event:      feedbackEvent,
 		OccurredAt: occurredAt,
@@ -459,35 +455,4 @@ func (c *Client) authorizeRequest(request *http.Request) error {
 	token.SetAuthHeader(request)
 
 	return nil
-}
-
-func isValidFeedbackType(feedbackType FeedbackType) bool {
-	switch feedbackType {
-	case
-		PaymentAccepted,
-		PaymentDeclined,
-		PaymentDeclinedByRiskAnalysis,
-		PaymentDeclinedByAcquirer,
-		PaymentDeclinedByBusiness,
-		PaymentDeclinedByManualReview,
-		PaymentAcceptedByThirdParty,
-		LoginAccepted,
-		LoginDeclined,
-		SignupAccepted,
-		SignupDeclined,
-		ChallengePassed,
-		ChallengeFailed,
-		PasswordChangedSuccessfully,
-		PasswordChangeFailed,
-		Verified,
-		NotVerified,
-		Chargeback,
-		PromotionAbuse,
-		AccountTakeover,
-		MposFraud,
-		ChargebackNotification:
-		return true
-	default:
-		return false
-	}
 }

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -680,14 +680,6 @@ func (suite *IncogniaTestSuite) TestForbiddenRegisterFeedback() {
 	suite.EqualError(err, "403 Forbidden")
 }
 
-func (suite *IncogniaTestSuite) TestErrorRegisterFeedbackInvalidFeedbackType() {
-	feedbackServer := suite.mockFeedbackEndpoint(token, postFeedbackRequestBodyFixture)
-	defer feedbackServer.Close()
-
-	err := suite.client.RegisterFeedback("invalid-type", postFeedbackRequestBodyFixture.OccurredAt, feedbackIdentifiersFixture)
-	suite.EqualError(err, ErrInvalidFeedbackType.Error())
-}
-
 func (suite *IncogniaTestSuite) TestErrorsRegisterFeedback() {
 	errors := []int{http.StatusBadRequest, http.StatusInternalServerError}
 	for _, status := range errors {
@@ -735,14 +727,6 @@ func (suite *IncogniaTestSuite) TestForbiddenRegisterFeedbackWithExpiration() {
 
 	err := suite.client.RegisterFeedbackWithExpiration(postFeedbackRequestWithExpirationBodyFixture.Event, postFeedbackRequestWithExpirationBodyFixture.OccurredAt, postFeedbackRequestWithExpirationBodyFixture.ExpiresAt, feedbackIdentifiersFixture)
 	suite.EqualError(err, "403 Forbidden")
-}
-
-func (suite *IncogniaTestSuite) TestErrorRegisterFeedbackWithExpirationInvalidFeedbackType() {
-	feedbackServer := suite.mockFeedbackEndpoint(token, postFeedbackRequestWithExpirationBodyFixture)
-	defer feedbackServer.Close()
-
-	err := suite.client.RegisterFeedbackWithExpiration("invalid-type", postFeedbackRequestWithExpirationBodyFixture.OccurredAt, postFeedbackRequestWithExpirationBodyFixture.ExpiresAt, feedbackIdentifiersFixture)
-	suite.EqualError(err, ErrInvalidFeedbackType.Error())
 }
 
 func (suite *IncogniaTestSuite) TestErrorsRegisterFeedbackWithExpiration() {


### PR DESCRIPTION
If we restrict in the library, it is not possible to use it for custom feedback types.