### PR TITLE
feat: add register web signup function

### DIFF
--- a/incognia.go
+++ b/incognia.go
@@ -100,15 +100,16 @@ type Address struct {
 }
 
 type Signup struct {
-	InstallationID string
-	RequestToken   string
-	SessionToken   string
-	AppVersion     string
-	DeviceOs       string
-	Address        *Address
-	AccountID      string
-	PolicyID       string
-	ExternalID     string
+	InstallationID   string
+	RequestToken     string
+	SessionToken     string
+	AppVersion       string
+	DeviceOs         string
+	Address          *Address
+	AccountID        string
+	PolicyID         string
+	ExternalID       string
+	CustomProperties map[string]interface{}
 }
 
 func validateLocation(location *Location) error {
@@ -204,6 +205,31 @@ func (c *Client) RegisterSignupWithParams(params *Signup) (ret *SignupAssessment
 	return c.registerSignup(params)
 }
 
+func (c *Client) RegisterWebSignup(requestToken string, policyID string) (ret *SignupAssessment, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+			ret = nil
+		}
+	}()
+
+	return c.registerSignup(&Signup{
+		RequestToken: requestToken,
+		PolicyID:     policyID,
+	})
+}
+
+func (c *Client) RegisterWebSignupWithParams(params *Signup) (ret *SignupAssessment, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+			ret = nil
+		}
+	}()
+
+	return c.registerSignup(params)
+}
+
 func (c *Client) registerSignup(params *Signup) (ret *SignupAssessment, err error) {
 	if params == nil {
 		return nil, ErrMissingSignup
@@ -213,14 +239,15 @@ func (c *Client) registerSignup(params *Signup) (ret *SignupAssessment, err erro
 	}
 
 	requestBody := postAssessmentRequestBody{
-		InstallationID: params.InstallationID,
-		RequestToken:   params.RequestToken,
-		SessionToken:   params.SessionToken,
-		AccountID:      params.AccountID,
-		PolicyID:       params.PolicyID,
-		ExternalID:     params.ExternalID,
-		AppVersion:     params.AppVersion,
-		DeviceOs:       strings.ToLower(params.DeviceOs),
+		InstallationID:   params.InstallationID,
+		RequestToken:     params.RequestToken,
+		SessionToken:     params.SessionToken,
+		AccountID:        params.AccountID,
+		PolicyID:         params.PolicyID,
+		ExternalID:       params.ExternalID,
+		AppVersion:       params.AppVersion,
+		DeviceOs:         strings.ToLower(params.DeviceOs),
+		CustomProperties: params.CustomProperties,
 	}
 	if params.Address != nil {
 		requestBody.AddressLine = params.Address.AddressLine

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -38,7 +38,17 @@ var (
 	emptyQueryString         map[string][]string = nil
 	queryStringWithFalseEval                     = map[string][]string{"eval": []string{"false"}}
 	queryStringWithTrueEval                      = map[string][]string{"eval": []string{"true"}}
-	locationFixtureFull                          = &Location{
+	customPropertiesFixture                      = map[string]interface{}{
+		"user_id":       "a9f7e3b2-24cd-4d3e-b6e1-98d1234c5678",
+		"is_verified":   true,
+		"last_latitude": -23.55052,
+		"preferences": map[string]interface{}{
+			"notifications_enabled": true,
+			"language":              "en-US",
+		},
+		"metadata": nil,
+	}
+	locationFixtureFull = &Location{
 		Latitude:    &floatVar,
 		Longitude:   &floatVar,
 		CollectedAt: &FixedCollectedAt,
@@ -131,6 +141,19 @@ var (
 		AccountID:  "account-id",
 		PolicyID:   "policy-id",
 		ExternalID: "external-id",
+	}
+	postWebSignupRequestBodyWithAllParamsFixture = &postAssessmentRequestBody{
+		RequestToken:     requestToken,
+		AccountID:        "account-id",
+		PolicyID:         "policy-id",
+		CustomProperties: customPropertiesFixture,
+	}
+	postWebSignupRequestBodyFixture = &postAssessmentRequestBody{
+		RequestToken: requestToken,
+		PolicyID:     "policy-id",
+	}
+	postWebSignupRequestBodyRequiredFieldsFixture = &postAssessmentRequestBody{
+		RequestToken: requestToken,
 	}
 	postSignupRequestBodyRequiredFieldsFixture = &postAssessmentRequestBody{
 		InstallationID: installationId,
@@ -620,6 +643,20 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignupWithParams() {
 	suite.Equal(signupAssessmentFixture, response)
 }
 
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebSignupWithParams() {
+	signupServer := suite.mockPostSignupsEndpoint(token, postWebSignupRequestBodyWithAllParamsFixture, signupAssessmentFixture)
+	defer signupServer.Close()
+
+	response, err := suite.client.RegisterWebSignupWithParams(&Signup{
+		RequestToken:     postWebSignupRequestBodyWithAllParamsFixture.RequestToken,
+		AccountID:        postWebSignupRequestBodyWithAllParamsFixture.AccountID,
+		PolicyID:         postWebSignupRequestBodyWithAllParamsFixture.PolicyID,
+		CustomProperties: postWebSignupRequestBodyWithAllParamsFixture.CustomProperties,
+	})
+	suite.NoError(err)
+	suite.Equal(signupAssessmentFixture, response)
+}
+
 func (suite *IncogniaTestSuite) TestSuccessRegisterSignup() {
 	signupServer := suite.mockPostSignupsEndpoint(token, postSignupRequestBodyFixture, signupAssessmentFixture)
 	defer signupServer.Close()
@@ -634,6 +671,15 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignupNilOptional() {
 	defer signupServer.Close()
 
 	response, err := suite.client.RegisterSignup(postSignupRequestBodyRequiredFieldsFixture.InstallationID, nil)
+	suite.NoError(err)
+	suite.Equal(signupAssessmentFixture, response)
+}
+
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebSignupNilOptional() {
+	signupServer := suite.mockPostSignupsEndpoint(token, postWebSignupRequestBodyRequiredFieldsFixture, signupAssessmentFixture)
+	defer signupServer.Close()
+
+	response, err := suite.client.RegisterWebSignup(postWebSignupRequestBodyRequiredFieldsFixture.RequestToken, "")
 	suite.NoError(err)
 	suite.Equal(signupAssessmentFixture, response)
 }
@@ -654,8 +700,30 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignupAfterTokenExpiration() 
 	suite.Equal(signupAssessmentFixture, response)
 }
 
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebSignupAfterTokenExpiration() {
+	signupServer := suite.mockPostSignupsEndpoint(token, postWebSignupRequestBodyFixture, signupAssessmentFixture)
+	defer signupServer.Close()
+
+	response, err := suite.client.RegisterWebSignup(postWebSignupRequestBodyFixture.RequestToken, postWebSignupRequestBodyFixture.PolicyID)
+	suite.NoError(err)
+	suite.Equal(signupAssessmentFixture, response)
+
+	token, _ := suite.client.tokenProvider.GetToken()
+	token.(*accessToken).ExpiresIn = 0
+
+	response, err = suite.client.RegisterWebSignup(postWebSignupRequestBodyFixture.RequestToken, postWebSignupRequestBodyFixture.PolicyID)
+	suite.NoError(err)
+	suite.Equal(signupAssessmentFixture, response)
+}
+
 func (suite *IncogniaTestSuite) TestRegisterSignupEmptyInstallationId() {
 	response, err := suite.client.RegisterSignup("", &Address{})
+	suite.EqualError(err, ErrMissingIdentifier.Error())
+	suite.Nil(response)
+}
+
+func (suite *IncogniaTestSuite) TestRegisterWebSignupEmptyRequestToken() {
+	response, err := suite.client.RegisterWebSignup("", "policy-id")
 	suite.EqualError(err, ErrMissingIdentifier.Error())
 	suite.Nil(response)
 }


### PR DESCRIPTION
## Proposed changes

This commit adds a `RegisterWebSignup` function.

## Additional context

- In terms of functionality, this PR allows users to pass a `CustomProperties` object in the signup request.
- Additionally, it creates a semantic distiction between mobile and web signups
- A similar function is present in the Java API library and this PR will also help maintain consistency across our libs.

## Checklist

- [x] Style check and tests pass locally with my changes, as well as on identical workflow on forked repository
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the updated request signature works on the live API endpoint