### PR TITLE
feat: adds web login function

### DIFF
--- a/incognia_test.go
+++ b/incognia_test.go
@@ -721,26 +721,6 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignupAfterTokenExpiration() 
 	suite.Equal(signupAssessmentFixture, response)
 }
 
-// func (suite *IncogniaTestSuite) TestSuccessRegisterWebSignupAfterTokenExpiration() {
-// 	signupServer := suite.mockPostSignupsEndpoint(token, postWebSignupRequestBodyFixture, signupAssessmentFixture)
-// 	defer signupServer.Close()
-
-// 	response, err := suite.client.RegisterWebSignup(&WebSignup{
-// 		RequestToken: postWebSignupRequestBodyRequiredFieldsFixture.RequestToken,
-// 	})
-// 	suite.NoError(err)
-// 	suite.Equal(signupAssessmentFixture, response)
-
-// 	token, _ := suite.client.tokenProvider.GetToken()
-// 	token.(*accessToken).ExpiresIn = 0
-
-// 	response, err = suite.client.RegisterWebSignup(&WebSignup{
-// 		RequestToken: postWebSignupRequestBodyRequiredFieldsFixture.RequestToken,
-// 	})
-// 	suite.NoError(err)
-// 	suite.Equal(signupAssessmentFixture, response)
-// }
-
 func (suite *IncogniaTestSuite) TestRegisterSignupEmptyInstallationId() {
 	response, err := suite.client.RegisterSignup("", &Address{})
 	suite.EqualError(err, ErrMissingIdentifier.Error())
@@ -1065,7 +1045,14 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithEval() {
 	suite.Equal(transactionAssessmentFixture, response)
 }
 
-// aqui
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebLoginWithEval() {
+	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, queryStringWithTrueEval)
+	defer transactionServer.Close()
+
+	response, err := suite.client.RegisterWebLogin(loginWebFixtureWithShouldEval)
+	suite.NoError(err)
+	suite.Equal(transactionAssessmentFixture, response)
+}
 
 func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithFalseEval() {
 	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginRequestBodyFixture, transactionAssessmentFixture, queryStringWithFalseEval)
@@ -1076,7 +1063,14 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithFalseEval() {
 	suite.Equal(emptyTransactionAssessmentFixture, response)
 }
 
-// aqui
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebLoginWithFalseEval() {
+	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, queryStringWithFalseEval)
+	defer transactionServer.Close()
+
+	response, err := suite.client.RegisterWebLogin(loginWebFixtureWithShouldNotEval)
+	suite.NoError(err)
+	suite.Equal(emptyTransactionAssessmentFixture, response)
+}
 
 func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWeb() {
 	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, emptyQueryString)

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -514,12 +514,28 @@ var (
 		PolicyID:       "policy-id",
 		Eval:           &shouldNotEval,
 	}
-	loginWebFixture = &Login{
-		AccountID:               "account-id",
-		ExternalID:              "external-id",
-		PolicyID:                "policy-id",
-		PaymentMethodIdentifier: "payment-method-identifier",
-		RequestToken:            requestToken,
+	loginWebFixture = &WebLogin{
+		AccountID:        "account-id",
+		ExternalID:       "external-id",
+		PolicyID:         "policy-id",
+		RequestToken:     requestToken,
+		CustomProperties: customProperty,
+	}
+	loginWebFixtureWithShouldEval = &WebLogin{
+		AccountID:        "account-id",
+		ExternalID:       "external-id",
+		PolicyID:         "policy-id",
+		RequestToken:     requestToken,
+		Eval:             &shouldEval,
+		CustomProperties: customProperty,
+	}
+	loginWebFixtureWithShouldNotEval = &WebLogin{
+		AccountID:        "account-id",
+		ExternalID:       "external-id",
+		PolicyID:         "policy-id",
+		RequestToken:     requestToken,
+		Eval:             &shouldNotEval,
+		CustomProperties: customProperty,
 	}
 	loginFixtureWithLocation = &Login{
 		InstallationID: &installationId,
@@ -538,12 +554,12 @@ var (
 		CustomProperties:        customProperty,
 	}
 	postLoginWebRequestBodyFixture = &postTransactionRequestBody{
-		AccountID:               "account-id",
-		ExternalID:              "external-id",
-		PolicyID:                "policy-id",
-		PaymentMethodIdentifier: "payment-method-identifier",
-		Type:                    loginType,
-		RequestToken:            requestToken,
+		AccountID:        "account-id",
+		ExternalID:       "external-id",
+		PolicyID:         "policy-id",
+		Type:             loginType,
+		RequestToken:     requestToken,
+		CustomProperties: customProperty,
 	}
 	postLoginRequestBodyWithLocationFixture = &postTransactionRequestBody{
 		InstallationID: &installationId,
@@ -1031,6 +1047,15 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLogin() {
 	suite.Equal(transactionAssessmentFixture, response)
 }
 
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebLogin() {
+	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, emptyQueryString)
+	defer transactionServer.Close()
+
+	response, err := suite.client.RegisterWebLogin(loginWebFixture)
+	suite.NoError(err)
+	suite.Equal(transactionAssessmentFixture, response)
+}
+
 func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithEval() {
 	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginRequestBodyFixture, transactionAssessmentFixture, queryStringWithTrueEval)
 	defer transactionServer.Close()
@@ -1039,6 +1064,8 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithEval() {
 	suite.NoError(err)
 	suite.Equal(transactionAssessmentFixture, response)
 }
+
+// aqui
 
 func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithFalseEval() {
 	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginRequestBodyFixture, transactionAssessmentFixture, queryStringWithFalseEval)
@@ -1049,11 +1076,13 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWithFalseEval() {
 	suite.Equal(emptyTransactionAssessmentFixture, response)
 }
 
+// aqui
+
 func (suite *IncogniaTestSuite) TestSuccessRegisterLoginWeb() {
 	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, emptyQueryString)
 	defer transactionServer.Close()
 
-	response, err := suite.client.registerLogin(loginWebFixture)
+	response, err := suite.client.registerWebLogin(loginWebFixture)
 	suite.NoError(err)
 	suite.Equal(transactionAssessmentFixture, response)
 }

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -1097,6 +1097,22 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterLoginAfterTokenExpiration() {
 	suite.Equal(transactionAssessmentFixture, response)
 }
 
+func (suite *IncogniaTestSuite) TestSuccessRegisterWebLoginAfterTokenExpiration() {
+	transactionServer := suite.mockPostTransactionsEndpoint(token, postLoginWebRequestBodyFixture, transactionAssessmentFixture, emptyQueryString)
+	defer transactionServer.Close()
+
+	response, err := suite.client.RegisterWebLogin(loginWebFixture)
+	suite.NoError(err)
+	suite.Equal(transactionAssessmentFixture, response)
+
+	token, _ := suite.client.tokenProvider.GetToken()
+	token.(*accessToken).ExpiresIn = 0
+
+	response, err = suite.client.RegisterWebLogin(loginWebFixture)
+	suite.NoError(err)
+	suite.Equal(transactionAssessmentFixture, response)
+}
+
 func (suite *IncogniaTestSuite) TestRegisterLoginNilLogin() {
 	response, err := suite.client.RegisterLogin(nil)
 	suite.EqualError(err, ErrMissingLogin.Error())


### PR DESCRIPTION
## Proposed changes

Adds a `RegisterWebLogin` function with relevant fields, so as to standardize the API library signanatures (Python and Java libs already include this method)

Fields: (as per API reference's `PostWebLoginTransactionRequest`):

- `AccountID`
- `PolicyID`
- `ExternalID`
- `RequestToken`
- `CustomProperties`

This separates neatly the fields expected for web logins, even though the generic `RegisterLogin` function includes these fields

## Checklist
- [x] Style check and tests pass locally with my changes and on forked repo with same workflow
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the changes on the live API endpoint
