### PR TITLE
feat: add store login to payments requests

### DIFF
--- a/incognia.go
+++ b/incognia.go
@@ -58,6 +58,7 @@ type Payment struct {
 	AccountID        string
 	ExternalID       string
 	PolicyID         string
+	StoreID          string
 	Location         *Location
 	Coupon           *CouponType
 	Addresses        []*TransactionAddress
@@ -401,6 +402,7 @@ func (c *Client) registerPayment(payment *Payment) (ret *TransactionAssessment, 
 		Type:             paymentType,
 		AccountID:        payment.AccountID,
 		PolicyID:         payment.PolicyID,
+		StoreID:          payment.StoreID,
 		Location:         payment.Location,
 		Coupon:           payment.Coupon,
 		ExternalID:       payment.ExternalID,

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -244,6 +244,7 @@ var (
 			Id:          "identifier",
 			Name:        "CouponName",
 		},
+		StoreID:          "store-id",
 		CustomProperties: customProperty,
 		Addresses: []*TransactionAddress{
 			{
@@ -348,6 +349,7 @@ var (
 		AccountID:      "account-id",
 		ExternalID:     "external-id",
 		PolicyID:       "policy-id",
+		StoreID:        "store-id",
 		DeviceOs:       "android",
 		AppVersion:     "1.2.3",
 		Coupon: &CouponType{

--- a/request_types.go
+++ b/request_types.go
@@ -169,5 +169,6 @@ type postTransactionRequestBody struct {
 	PaymentMethods          []*PaymentMethod       `json:"payment_methods,omitempty"`
 	SessionToken            *string                `json:"session_token,omitempty"`
 	RequestToken            string                 `json:"request_token,omitempty"`
+	StoreID                 string                 `json:"store_id,omitempty"`
 	CustomProperties        map[string]interface{} `json:"custom_properties,omitempty"`
 }


### PR DESCRIPTION
## Proposed changes

Adds the `StoreID` field to the requests to `/payments`

## Checklist
- [x] Style check and tests pass locally with my changes and on forked repo with same workflow
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the changes on the live API endpoint
