### PR TITLE
feat: adds Person ID to all endpoints

### DIFF
--- a/incognia.go
+++ b/incognia.go
@@ -66,6 +66,7 @@ type Payment struct {
 	Methods          []*PaymentMethod
 	Eval             *bool
 	CustomProperties map[string]interface{}
+	PersonID         *PersonID
 }
 
 type WebLogin struct {
@@ -75,6 +76,7 @@ type WebLogin struct {
 	PolicyID         string
 	Eval             *bool
 	CustomProperties map[string]interface{}
+	PersonID         *PersonID
 }
 
 type Login struct {
@@ -90,6 +92,7 @@ type Login struct {
 	AppVersion              string
 	DeviceOs                string
 	CustomProperties        map[string]interface{}
+	PersonID                *PersonID
 }
 
 type FeedbackIdentifiers struct {
@@ -101,6 +104,7 @@ type FeedbackIdentifiers struct {
 	SignupID       string
 	AccountID      string
 	ExternalID     string
+	PersonID       *PersonID
 }
 
 type Address struct {
@@ -119,6 +123,7 @@ type Signup struct {
 	AccountID      string
 	PolicyID       string
 	ExternalID     string
+	PersonID       *PersonID
 }
 
 type WebSignup struct {
@@ -126,6 +131,7 @@ type WebSignup struct {
 	PolicyID         string
 	AccountID        string
 	CustomProperties map[string]interface{}
+	PersonID         *PersonID
 }
 
 func validateLocation(location *Location) error {
@@ -249,6 +255,7 @@ func (c *Client) registerSignup(params *Signup) (ret *SignupAssessment, err erro
 		ExternalID:     params.ExternalID,
 		AppVersion:     params.AppVersion,
 		DeviceOs:       strings.ToLower(params.DeviceOs),
+		PersonID:       params.PersonID,
 	}
 	if params.Address != nil {
 		requestBody.AddressLine = params.Address.AddressLine
@@ -289,6 +296,7 @@ func (c *Client) registerWebSignup(params *WebSignup) (ret *SignupAssessment, er
 		PolicyID:         params.PolicyID,
 		AccountID:        params.AccountID,
 		CustomProperties: params.CustomProperties,
+		PersonID:         params.PersonID,
 	}
 
 	requestBodyBytes, err := json.Marshal(requestBody)
@@ -346,6 +354,7 @@ func (c *Client) registerFeedback(feedbackEvent FeedbackType, occurredAt *time.T
 		requestBody.SignupID = feedbackIdentifiers.SignupID
 		requestBody.AccountID = feedbackIdentifiers.AccountID
 		requestBody.ExternalID = feedbackIdentifiers.ExternalID
+		requestBody.PersonID = feedbackIdentifiers.PersonID
 	}
 	requestBodyBytes, err := json.Marshal(requestBody)
 	if err != nil {
@@ -412,6 +421,7 @@ func (c *Client) registerPayment(payment *Payment) (ret *TransactionAssessment, 
 		AppVersion:       payment.AppVersion,
 		DeviceOs:         strings.ToLower(payment.DeviceOs),
 		CustomProperties: payment.CustomProperties,
+		PersonID:         payment.PersonID,
 	})
 	if err != nil {
 		return nil, err
@@ -481,6 +491,7 @@ func (c *Client) registerLogin(login *Login) (*TransactionAssessment, error) {
 		AppVersion:              login.AppVersion,
 		DeviceOs:                strings.ToLower(login.DeviceOs),
 		CustomProperties:        login.CustomProperties,
+		PersonID:                login.PersonID,
 	})
 	if err != nil {
 		return nil, err
@@ -539,6 +550,7 @@ func (c *Client) registerWebLogin(webLogin *WebLogin) (*TransactionAssessment, e
 		ExternalID:       webLogin.ExternalID,
 		RequestToken:     webLogin.RequestToken,
 		CustomProperties: webLogin.CustomProperties,
+		PersonID:         webLogin.PersonID,
 	})
 	if err != nil {
 		return nil, err

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -141,12 +141,20 @@ var (
 		AccountID:  "account-id",
 		PolicyID:   "policy-id",
 		ExternalID: "external-id",
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postWebSignupRequestBodyWithAllParamsFixture = &postAssessmentRequestBody{
 		RequestToken:     requestToken,
 		AccountID:        "account-id",
 		PolicyID:         "policy-id",
 		CustomProperties: customPropertiesFixture,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postWebSignupRequestBodyFixture = &postAssessmentRequestBody{
 		RequestToken: requestToken,
@@ -177,6 +185,10 @@ var (
 		SignupID:       "some-signup-id",
 		AccountID:      "some-account-id",
 		ExternalID:     "some-external-id",
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postFeedbackRequestWithExpirationBodyFixture = &postFeedbackRequestBody{
 		Event:          SignupAccepted,
@@ -203,6 +215,10 @@ var (
 		SignupID:       "some-signup-id",
 		AccountID:      "some-account-id",
 		ExternalID:     "some-external-id",
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	emptyTransactionAssessmentFixture = &TransactionAssessment{}
 	transactionAssessmentFixture      = &TransactionAssessment{
@@ -285,6 +301,10 @@ var (
 				},
 			},
 		},
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postPaymentWebRequestBodyFixture = &postTransactionRequestBody{
 		RequestToken: requestToken,
@@ -337,6 +357,10 @@ var (
 					ExpiryMonth:    "10",
 				},
 			},
+		},
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
 		},
 	}
 	postPaymentRequestBodyRequiredFieldsFixture = &postTransactionRequestBody{
@@ -399,6 +423,10 @@ var (
 				},
 			},
 		},
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	paymentWebFixture = &Payment{
 		RequestToken: requestToken,
@@ -451,6 +479,10 @@ var (
 				},
 			},
 		},
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	paymentFixtureRequiredFields = &Payment{
 		InstallationID: &installationId,
@@ -491,6 +523,10 @@ var (
 		AppVersion:              "1.2.3",
 		CustomProperties:        customProperty,
 		PaymentMethodIdentifier: "payment-method-identifier",
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postPaymentRequestBodyWithLocationFixture = &postTransactionRequestBody{
 		InstallationID: &installationId,
@@ -508,6 +544,10 @@ var (
 		PaymentMethodIdentifier: "payment-method-identifier",
 		Eval:                    &shouldEval,
 		CustomProperties:        customProperty,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	loginFixtureWithShouldNotEval = &Login{
 		InstallationID: &installationId,
@@ -522,6 +562,10 @@ var (
 		PolicyID:         "policy-id",
 		RequestToken:     requestToken,
 		CustomProperties: customProperty,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	loginWebFixtureWithShouldEval = &WebLogin{
 		AccountID:        "account-id",
@@ -530,6 +574,10 @@ var (
 		RequestToken:     requestToken,
 		Eval:             &shouldEval,
 		CustomProperties: customProperty,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	loginWebFixtureWithShouldNotEval = &WebLogin{
 		AccountID:        "account-id",
@@ -554,6 +602,10 @@ var (
 		PaymentMethodIdentifier: "payment-method-identifier",
 		Type:                    loginType,
 		CustomProperties:        customProperty,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postLoginWebRequestBodyFixture = &postTransactionRequestBody{
 		AccountID:        "account-id",
@@ -562,6 +614,10 @@ var (
 		Type:             loginType,
 		RequestToken:     requestToken,
 		CustomProperties: customProperty,
+		PersonID: &PersonID{
+			Type:  "cpf",
+			Value: "12345678901",
+		},
 	}
 	postLoginRequestBodyWithLocationFixture = &postTransactionRequestBody{
 		InstallationID: &installationId,
@@ -659,6 +715,7 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignupWithParams() {
 		AccountID:      postSignupRequestBodyWithAllParamsFixture.AccountID,
 		PolicyID:       postSignupRequestBodyWithAllParamsFixture.PolicyID,
 		ExternalID:     postSignupRequestBodyWithAllParamsFixture.ExternalID,
+		PersonID:       postSignupRequestBodyWithAllParamsFixture.PersonID,
 	})
 	suite.NoError(err)
 	suite.Equal(signupAssessmentFixture, response)
@@ -673,6 +730,7 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterWebSignupFull() {
 		AccountID:        postWebSignupRequestBodyWithAllParamsFixture.AccountID,
 		PolicyID:         postWebSignupRequestBodyWithAllParamsFixture.PolicyID,
 		CustomProperties: postWebSignupRequestBodyWithAllParamsFixture.CustomProperties,
+		PersonID:         postWebSignupRequestBodyWithAllParamsFixture.PersonID,
 	})
 	suite.NoError(err)
 	suite.Equal(signupAssessmentFixture, response)

--- a/request_types.go
+++ b/request_types.go
@@ -40,6 +40,7 @@ type postAssessmentRequestBody struct {
 	PolicyID          string                 `json:"policy_id,omitempty"`
 	ExternalID        string                 `json:"external_id,omitempty"`
 	CustomProperties  map[string]interface{} `json:"custom_properties,omitempty"`
+	PersonID          *PersonID              `json:"person_id,omitempty"`
 }
 
 type FeedbackType string
@@ -85,6 +86,7 @@ type postFeedbackRequestBody struct {
 	SignupID       string       `json:"signup_id,omitempty"`
 	AccountID      string       `json:"account_id,omitempty"`
 	ExternalID     string       `json:"external_id,omitempty"`
+	PersonID       *PersonID    `json:"person_id,omitempty"`
 }
 
 type AddressType string
@@ -171,4 +173,10 @@ type postTransactionRequestBody struct {
 	RequestToken            string                 `json:"request_token,omitempty"`
 	StoreID                 string                 `json:"store_id,omitempty"`
 	CustomProperties        map[string]interface{} `json:"custom_properties,omitempty"`
+	PersonID                *PersonID              `json:"person_id,omitempty"`
+}
+
+type PersonID struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }


### PR DESCRIPTION
## Proposed changes

Adds optional `personID` field as an optional parameter to the request bodies corresponding to:

* `Signup`
* `WebSignup`
* `Login`
* `WebLogin`
* `Payment`
* `Feedback`


## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint