### PR TITLE
feat: adds debtor and creditor account parameters

### DIFF
--- a/incognia.go
+++ b/incognia.go
@@ -67,6 +67,8 @@ type Payment struct {
 	Eval             *bool
 	CustomProperties map[string]interface{}
 	PersonID         *PersonID
+	DebtorAccount    *BankAccountInfo
+	CreditorAccount  *BankAccountInfo
 }
 
 type WebLogin struct {
@@ -422,6 +424,8 @@ func (c *Client) registerPayment(payment *Payment) (ret *TransactionAssessment, 
 		DeviceOs:         strings.ToLower(payment.DeviceOs),
 		CustomProperties: payment.CustomProperties,
 		PersonID:         payment.PersonID,
+		DebtorAccount:    payment.DebtorAccount,
+		CreditorAccount:  payment.CreditorAccount,
 	})
 	if err != nil {
 		return nil, err

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -48,6 +48,22 @@ var (
 		},
 		"metadata": nil,
 	}
+	pixKeyArrayFixture = []*PixKey{
+		{Type: "cpf", Value: "12345678901"},
+		{Type: "email", Value: "legit_person@gmail.com"},
+	}
+	bankAccountInfoFixture = &BankAccountInfo{
+		AccountType:       "savings",
+		AccountPurpose:    "rural",
+		HolderType:        "business",
+		HolderTaxID:       &PersonID{Type: "cpf", Value: "12345678901"},
+		Country:           "BR",
+		IspbCode:          "18236120",
+		BranchCode:        "0001",
+		AccountNumber:     "123456",
+		AccountCheckDigit: "0",
+		PixKeys:           pixKeyArrayFixture,
+	}
 	locationFixtureFull = &Location{
 		Latitude:    &floatVar,
 		Longitude:   &floatVar,
@@ -305,6 +321,8 @@ var (
 			Type:  "cpf",
 			Value: "12345678901",
 		},
+		DebtorAccount:   bankAccountInfoFixture,
+		CreditorAccount: bankAccountInfoFixture,
 	}
 	postPaymentWebRequestBodyFixture = &postTransactionRequestBody{
 		RequestToken: requestToken,
@@ -427,6 +445,8 @@ var (
 			Type:  "cpf",
 			Value: "12345678901",
 		},
+		DebtorAccount:   bankAccountInfoFixture,
+		CreditorAccount: bankAccountInfoFixture,
 	}
 	paymentWebFixture = &Payment{
 		RequestToken: requestToken,

--- a/request_types.go
+++ b/request_types.go
@@ -41,6 +41,8 @@ type postAssessmentRequestBody struct {
 	ExternalID        string                 `json:"external_id,omitempty"`
 	CustomProperties  map[string]interface{} `json:"custom_properties,omitempty"`
 	PersonID          *PersonID              `json:"person_id,omitempty"`
+	DebtorAccount     *BankAccountInfo       `json:"debtor_account,omitempty"`
+	CreditorAccount   *BankAccountInfo       `json:"creditor_account,omitempty"`
 }
 
 type FeedbackType string
@@ -174,9 +176,29 @@ type postTransactionRequestBody struct {
 	StoreID                 string                 `json:"store_id,omitempty"`
 	CustomProperties        map[string]interface{} `json:"custom_properties,omitempty"`
 	PersonID                *PersonID              `json:"person_id,omitempty"`
+	DebtorAccount           *BankAccountInfo       `json:"debtor_account,omitempty"`
+	CreditorAccount         *BankAccountInfo       `json:"creditor_account,omitempty"`
 }
 
 type PersonID struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
+}
+
+type PixKey struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type BankAccountInfo struct {
+	AccountType       string    `json:"account_type"`
+	AccountPurpose    string    `json:"account_purpose"`
+	HolderType        string    `json:"holder_type"`
+	HolderTaxID       *PersonID `json:"holder_tax_id"`
+	Country           string    `json:"country"`
+	IspbCode          string    `json:"ispb_code"`
+	BranchCode        string    `json:"branch_code"`
+	AccountNumber     string    `json:"account_number"`
+	AccountCheckDigit string    `json:"account_check_digit"`
+	PixKeys           []*PixKey `json:"pix_keys"`
 }


### PR DESCRIPTION
## Proposed changes

Adds `DebtorAccount` and `CreditorAccount` fields to the `registerPayment` method

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint