### PR TITLE
Fix manual refresh concurrency test flakiness

### DIFF
--- a/token_provider_test.go
+++ b/token_provider_test.go
@@ -104,23 +104,47 @@ func (suite *ManualRefreshTokenProviderTestSuite) TestManualRefreshConcurrency()
 	client.endpoints.Signups = signupServer.URL
 
 	var wg sync.WaitGroup
+	firstAttemptErrs := make(chan error, 5)
 
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
 
 		go func(wg *sync.WaitGroup) {
 			_, err := client.RegisterSignup("any-installation-id", addressFixture)
-			suite.Error(err)
-			if errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenNotFound) {
-				suite.tokenProvider.Refresh()
-			}
-			_, err = client.RegisterSignup("any-installation-id", addressFixture)
-			suite.NoError(err)
+			firstAttemptErrs <- err
 			wg.Done()
 		}(&wg)
 	}
 
 	wg.Wait()
+	close(firstAttemptErrs)
+
+	for err := range firstAttemptErrs {
+		suite.Error(err)
+		suite.True(errors.Is(err, ErrTokenExpired) || errors.Is(err, ErrTokenNotFound))
+	}
+
+	_, err := suite.tokenProvider.Refresh()
+	suite.NoError(err)
+
+	successErrs := make(chan error, 5)
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+
+		go func(wg *sync.WaitGroup) {
+			_, err := client.RegisterSignup("any-installation-id", addressFixture)
+			successErrs <- err
+			wg.Done()
+		}(&wg)
+	}
+
+	wg.Wait()
+	close(successErrs)
+
+	for err := range successErrs {
+		suite.NoError(err)
+	}
 }
 
 func TestManualRefreshTokenProviderTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary
- make `TestManualRefreshConcurrency` deterministic by separating first-attempt failures from post-refresh successes
- avoid refreshing from worker goroutines, which allowed some first requests to succeed depending on scheduling
- move assertions to the main test goroutine and verify the manual refresh flow explicitly

