### PR TITLE
Normalize User-Agent library version format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 #
 .idea/
+
+.DS_Store

--- a/incognia.go
+++ b/incognia.go
@@ -30,6 +30,28 @@ var (
 	ErrMissingLocationLatLong        = errors.New("location field missing latitude and/or longitude")
 )
 
+func libraryVersion() string {
+	if buildInfo, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range buildInfo.Deps {
+			if dep.Path == "repo.incognia.com/go/incognia" {
+				return dep.Version
+			}
+		}
+	}
+
+	return "unknown"
+}
+
+func buildUserAgent(libVersion string) string {
+	return fmt.Sprintf(
+		"incognia-go/%s (%s %s) Go/%s",
+		strings.TrimPrefix(libVersion, "v"),
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+	)
+}
+
 type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -193,22 +215,7 @@ func New(config *IncogniaClientConfig) (*Client, error) {
 		Timeout:      tokenRouteTimeout,
 	})
 
-	libVersion := "unknown"
-	if buildInfo, ok := debug.ReadBuildInfo(); ok {
-		for _, dep := range buildInfo.Deps {
-			if dep.Path == "repo.incognia.com/go/incognia" {
-				libVersion = dep.Version
-			}
-		}
-	}
-
-	userAgent := fmt.Sprintf(
-		"incognia-api-go/%s (%s %s) Go/%s",
-		libVersion,
-		runtime.GOOS,
-		runtime.GOARCH,
-		runtime.Version(),
-	)
+	userAgent := buildUserAgent(libraryVersion())
 
 	tokenProvider := config.TokenProvider
 	if tokenProvider == nil {

--- a/incognia_test.go
+++ b/incognia_test.go
@@ -2,10 +2,12 @@ package incognia
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -22,7 +24,7 @@ const (
 )
 
 var (
-	userAgentRegex   = regexp.MustCompile(`^incognia-api-go(/(v[0-9]+\.[0-9]+\.[0-9]+|unknown))? \([a-z]+ [a-z0-9]+\) Go/go[0-9]+\.[0-9]+\.[0-9]+$`)
+	userAgentRegex   = regexp.MustCompile(`^incognia-go/([0-9]+\.[0-9]+\.[0-9]+|unknown) \([a-z]+ [a-z0-9]+\) Go/go[0-9]+\.[0-9]+\.[0-9]+$`)
 	now              = time.Now()
 	floatVar         = -7.5432
 	FixedCollectedAt = time.Date(2025, time.March, 22, 12, 12, 12, 0, time.UTC)
@@ -886,6 +888,21 @@ var (
 		Location:       nil,
 	}
 )
+
+func TestBuildUserAgentTrimsVersionPrefix(t *testing.T) {
+	expected := fmt.Sprintf(
+		"incognia-go/1.1.1 (%s %s) Go/%s",
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Version(),
+	)
+
+	actual := buildUserAgent("v1.1.1")
+
+	if actual != expected {
+		t.Fatalf("expected %q, got %q", expected, actual)
+	}
+}
 
 type PanickingTokenProvider struct {
 	panicString string

--- a/token_client.go
+++ b/token_client.go
@@ -3,10 +3,7 @@ package incognia
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"runtime"
-	"runtime/debug"
 	"strconv"
 	"time"
 )
@@ -41,22 +38,7 @@ func NewTokenClient(config *TokenClientConfig) *TokenClient {
 		timeout = tokenNetClientTimeout
 	}
 
-	libVersion := "unknown"
-	if buildInfo, ok := debug.ReadBuildInfo(); ok {
-		for _, dep := range buildInfo.Deps {
-			if dep.Path == "repo.incognia.com/go/incognia" {
-				libVersion = dep.Version
-			}
-		}
-	}
-
-	userAgent := fmt.Sprintf(
-		"incognia-api-go/%s (%s %s) Go/%s",
-		libVersion,
-		runtime.GOOS,
-		runtime.GOARCH,
-		runtime.Version(),
-	)
+	userAgent := buildUserAgent(libraryVersion())
 
 	return &TokenClient{
 		ClientID:      config.ClientID,


### PR DESCRIPTION
## Summary
- change the SDK User-Agent prefix from `incognia-api-go` to `incognia-go` 
- remove the leading `v` from the SDK version in the `User-Agent` header
- add a direct test for the version formatting while keeping the existing request-level coverage

## References
As of today:
<img width="328" height="259" alt="image" src="https://github.com/user-attachments/assets/444bec90-27b8-41be-8e5c-2916fbf088f0" />
