### PR TITLE
feat: add actions to assessment responses

### DIFF
--- a/incognia_test.go
+++ b/incognia_test.go
@@ -92,6 +92,33 @@ var (
 		RequestID:      "some-request-id",
 		RiskAssessment: LowRisk,
 		Reasons:        []Reason{{Code: "mpos_fraud", Source: "global"}, {Code: "mpos_fraud", Source: "local"}},
+		Actions:        []string{"allow"},
+		Evidence: Evidence{
+			"device_model":                 "Moto Z2 Play",
+			"geocode_quality":              "good",
+			"address_quality":              "good",
+			"address_match":                "street",
+			"location_events_near_address": 38.0,
+			"location_events_quantity":     288.0,
+			"location_services": map[string]interface{}{
+				"location_permission_enabled": true,
+				"location_sensors_enabled":    true,
+			},
+			"device_integrity": map[string]interface{}{
+				"probable_root":       false,
+				"emulator":            false,
+				"gps_spoofing":        false,
+				"from_official_store": true,
+			},
+		},
+	}
+	signupAssessmentHighRiskFixture = &SignupAssessment{
+		ID:             "some-id",
+		DeviceID:       "some-device-id",
+		RequestID:      "some-request-id",
+		RiskAssessment: HighRisk,
+		Reasons:        []Reason{{Code: "mpos_fraud", Source: "global"}, {Code: "mpos_fraud", Source: "local"}},
+		Actions:        []string{"warn-user", "block"},
 		Evidence: Evidence{
 			"device_model":                 "Moto Z2 Play",
 			"geocode_quality":              "good",
@@ -268,6 +295,32 @@ var (
 		DeviceID:       "some-device-id",
 		RiskAssessment: LowRisk,
 		Reasons:        []Reason{{Code: "mpos_fraud", Source: "global"}, {Code: "mpos_fraud", Source: "local"}},
+		Actions:        []string{"allow"},
+		Evidence: Evidence{
+			"device_model":                 "Moto Z2 Play",
+			"geocode_quality":              "good",
+			"address_quality":              "good",
+			"address_match":                "street",
+			"location_events_near_address": 38.0,
+			"location_events_quantity":     288.0,
+			"location_services": map[string]interface{}{
+				"location_permission_enabled": true,
+				"location_sensors_enabled":    true,
+			},
+			"device_integrity": map[string]interface{}{
+				"probable_root":       false,
+				"emulator":            false,
+				"gps_spoofing":        false,
+				"from_official_store": true,
+			},
+		},
+	}
+	transactionAssessmentHighRiskFixture = &TransactionAssessment{
+		ID:             "some-id",
+		DeviceID:       "some-device-id",
+		RiskAssessment: HighRisk,
+		Reasons:        []Reason{{Code: "mpos_fraud", Source: "global"}, {Code: "mpos_fraud", Source: "local"}},
+		Actions:        []string{"warn-user", "block"},
 		Evidence: Evidence{
 			"device_model":                 "Moto Z2 Play",
 			"geocode_quality":              "good",
@@ -1026,6 +1079,24 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterSignup() {
 	suite.Equal(signupAssessmentFixture, response)
 }
 
+func (suite *IncogniaTestSuite) TestSuccessRegisterSignupActionsLowRisk() {
+	signupServer := suite.mockPostSignupsEndpoint(token, postSignupRequestBodyFixture, signupAssessmentFixture)
+	defer signupServer.Close()
+
+	response, err := suite.client.RegisterSignup(postSignupRequestBodyFixture.InstallationID, addressFixture)
+	suite.NoError(err)
+	suite.Equal([]string{"allow"}, response.Actions)
+}
+
+func (suite *IncogniaTestSuite) TestSuccessRegisterSignupActionsHighRisk() {
+	signupServer := suite.mockPostSignupsEndpoint(token, postSignupRequestBodyFixture, signupAssessmentHighRiskFixture)
+	defer signupServer.Close()
+
+	response, err := suite.client.RegisterSignup(postSignupRequestBodyFixture.InstallationID, addressFixture)
+	suite.NoError(err)
+	suite.Equal([]string{"warn-user", "block"}, response.Actions)
+}
+
 func (suite *IncogniaTestSuite) TestSuccessRegisterSignupNilOptional() {
 	signupServer := suite.mockPostSignupsEndpoint(token, postSignupRequestBodyRequiredFieldsFixture, signupAssessmentFixture)
 	defer signupServer.Close()
@@ -1209,6 +1280,15 @@ func (suite *IncogniaTestSuite) TestSuccessRegisterPayment() {
 
 	suite.NoError(err)
 	suite.Equal(transactionAssessmentFixture, response)
+}
+
+func (suite *IncogniaTestSuite) TestSuccessRegisterPaymentActionsHighRisk() {
+	transactionServer := suite.mockPostTransactionsEndpoint(token, postPaymentRequestBodyFixture, transactionAssessmentHighRiskFixture, emptyQueryString)
+	defer transactionServer.Close()
+
+	response, err := suite.client.RegisterPayment(paymentFixture)
+	suite.NoError(err)
+	suite.Equal([]string{"warn-user", "block"}, response.Actions)
 }
 
 func (suite *IncogniaTestSuite) TestSuccessRegisterPaymentWeb() {

--- a/response_types.go
+++ b/response_types.go
@@ -205,6 +205,7 @@ type SignupAssessment struct {
 	RiskAssessment Assessment `json:"risk_assessment"`
 	Evidence       Evidence   `json:"evidence,omitempty"`
 	Reasons        []Reason   `json:"reasons"`
+	Actions        []string   `json:"actions,omitempty"`
 	Signals        Signals    `json:"signals,omitempty"`
 }
 
@@ -214,5 +215,6 @@ type TransactionAssessment struct {
 	DeviceID       string     `json:"device_id"`
 	Evidence       Evidence   `json:"evidence,omitempty"`
 	Reasons        []Reason   `json:"reasons"`
+	Actions        []string   `json:"actions,omitempty"`
 	Signals        Signals    `json:"signals,omitempty"`
 }

--- a/response_types_test.go
+++ b/response_types_test.go
@@ -106,6 +106,22 @@ func (suite *EvidenceTestSuite) TestUnmarshalAssessmentWithoutEvidenceDoesNotFai
 	suite.Nil(a.Evidence)
 }
 
+func (suite *EvidenceTestSuite) TestUnmarshalAssessmentWithActionsDoesNotFail() {
+	payload := []byte(`{
+		"id":"1",
+		"risk_assessment":"low_risk",
+		"device_id":"device-1",
+		"actions":["allow"],
+		"reasons":[]
+	}`)
+
+	var a TransactionAssessment
+	err := json.Unmarshal(payload, &a)
+
+	suite.NoError(err)
+	suite.Equal([]string{"allow"}, a.Actions)
+}
+
 func (suite *EvidenceTestSuite) TestGetEvidenceAsInt64_WhenEvidenceNil_ReturnsNotFound() {
 	var evidence Evidence
 


### PR DESCRIPTION
## Summary
- add the root-level actions field to signup and transaction assessment DTOs
- cover actions decoding in integration-style client tests for low-risk and high-risk responses
- add a DTO unmarshal test for the new response field

## Evidences
<img width="807" height="95" alt="image" src="https://github.com/user-attachments/assets/5689ca1f-bf8c-42cd-a064-4724d29e5c36" />

